### PR TITLE
recognize and use prop:constructor-style-printer when converting structs

### DIFF
--- a/mzlib/pconvert.rkt
+++ b/mzlib/pconvert.rkt
@@ -5,6 +5,7 @@
            compatibility/mlist
 	   "pconvert-prop.rkt"
            racket/class
+           racket/struct
            racket/undefined)
   
   (provide show-sharing
@@ -466,6 +467,13 @@
                                   ,@(for/list ([v (in-vector (struct->vector expr))]
                                                [i (in-naturals)] #:unless (zero? i))
                                       (recur v)))]
+                               [(constructor-style-printer? expr)
+                                (let* ([constructor (constructor-style-printer-constructor expr)]
+                                       [constructor (if (symbol? constructor)
+                                                        constructor
+                                                        (string->symbol constructor))])
+                                  `(,constructor
+                                    ,@(map recur (constructor-style-printer-contents expr))))]
                                
                                ;; this case must be next to last, so that all of the
                                ;; things with object-name's fall into the cases above first


### PR DESCRIPTION
This changes `print-convert` to work with my other pull request to racket (https://github.com/racket/racket/pull/1337) so that it can recognize the new `prop:constructor-style-printer` property and use it when converting structs that have it.

``` racket
> (require racket/struct mzlib/pconvert)
> (struct point (x y) ; this struct is opaque and wouldn't print like this otherwise
    #:property prop:constructor-style-printer
    (list
     (lambda (p) 'point)
     (lambda (p) (list (point-x p) (point-y p)))))
> (print-convert (point 1 2))
(list 'point 1 2)
> (constructor-style-printing #true)
> (print-convert (point (list 1 2 3) (list 4 5 6)))
(list 'point (list 'list 1 2 3) (list 'list 4 5 6))
```
