### PR TITLE
add a typed version of pconvert-prop

### DIFF
--- a/pconvert-lib/typed/info.rkt
+++ b/pconvert-lib/typed/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+
+(define collection 'multi)

--- a/pconvert-lib/typed/mzlib/pconvert-prop.rkt
+++ b/pconvert-lib/typed/mzlib/pconvert-prop.rkt
@@ -1,0 +1,4 @@
+#lang typed/racket/base
+(require mzlib/pconvert-prop)
+
+(provide prop:print-converter)


### PR DESCRIPTION
The type annotation for prop:print-converter will be defined [typed/racket](https://github.com/capfredf/typed-racket/blob/f0b7d907fde05e1a1bd8b6c463ebf0a7da83179a/typed-racket-lib/typed-racket/base-env/base-env.rkt#L3519) for the sake of compatibility.

The pull request can't be merged until https://github.com/racket/typed-racket/pull/804 is merged